### PR TITLE
[UPD] - fix xml no attribute for sysmon plugin

### DIFF
--- a/dettectinator/plugins/datasources_import.py
+++ b/dettectinator/plugins/datasources_import.py
@@ -256,7 +256,7 @@ class DatasourceWindowsSysmon(DatasourceOssemBase):
             # If this is an event type with an onmatch == include attribute without child items this means
             # that nothing is being logged for this event type
             for config_item in config_items:
-                if config_item.attrib['onmatch'] == "include" and len(config_item.getchildren()) == 0:
+                if config_item.attrib['onmatch'] == "include" and len(list(config_item)) == 0:
                     continue
 
             data_source = str(record['Component']).title()


### PR DESCRIPTION
Fix the issue with XML.etree while using the datasource plugin `DatasourceWindowsSysmon`.

Code:

```python
import json


from dettectinator.dettectinator.plugins.datasources_import import DatasourceWindowsSysmon
from dettectinator.dettectinator import DettectDataSourcesAdministration

def datasources_sysmon_config():
    """
    Tests an import via DatasourceWindowsSysmon plugin.
    """
    parameters = {'sysmon_config': 'config_test.xml'}
    import_datasources_sysmon = DatasourceWindowsSysmon(parameters)
    datasources = import_datasources_sysmon.get_attack_datasources(['Windows'])
    print(json.dumps(datasources, indent=4))

if __name__ == '__main__':
    datasources_sysmon_config()
```

Error:
```
if config_item.attrib['onmatch'] == "include" and len(config_item.list()) == 0:
AttributeError: 'xml.etree.ElementTree.Element' object has no attribute 'list'
```