### PR TITLE
Fix rule location name when checking existing rules

### DIFF
--- a/dettectinator/dettectinator.py
+++ b/dettectinator/dettectinator.py
@@ -336,7 +336,7 @@ class DettectTechniquesAdministration(DettectBase):
                                 # Check if detection rule is in location field:
                                 rule_exist = False
                                 for loc in d['location']:
-                                    if rule_name in loc:
+                                    if location in loc:
                                         rule_exist = True
                                         break
 


### PR DESCRIPTION
Currently, if a similar named rule already exists, then the rule addition is wrongly skipped. The use of 'location' fixes that because it respects the whole rule name including the location prefix if needed and this allows adding a similarly named rule correctly.