### PR TITLE
Adding Sentinel Plugin support for subtechniques mapped to analytics rules

### DIFF
--- a/dettectinator/plugins/technique_import.py
+++ b/dettectinator/plugins/technique_import.py
@@ -370,7 +370,7 @@ class TechniqueDefenderIdentityRules(TechniqueBase):
                                     yield t, current_detection, None
                                 current_detection = None
             else:
-                print(f'Received HTTP status code "{resp.status_code}" on URL "{source_url}".')
+                raise Exception(f'TechniqueDefenderIdentityRules: Received HTTP status code "{resp.status_code}" on URL "{source_url}".')
 
 
 class TechniqueDefenderAlerts(TechniqueAzureAuthBase):

--- a/dettectinator/plugins/technique_import.py
+++ b/dettectinator/plugins/technique_import.py
@@ -273,6 +273,10 @@ class TechniqueSentinelAlertRules(TechniqueAzureAuthBase):
                 for technique in properties['techniques']:
                     use_case = properties['displayName']
                     yield technique, use_case, None
+            if 'subTechniques' in properties and properties['subTechniques']:
+                for technique in properties['subTechniques']:
+                    use_case = properties['displayName']
+                    yield technique, use_case, None
 
     def _get_sentinel_data(self, access_token: str) -> list:
         """
@@ -282,7 +286,7 @@ class TechniqueSentinelAlertRules(TechniqueAzureAuthBase):
         """
         url = f'https://management.azure.com/subscriptions/{self._subscription_id}/resourceGroups/{self._resource_group}/' + \
               f'providers/Microsoft.OperationalInsights/workspaces/{self._workspace}/providers/Microsoft.SecurityInsights/' + \
-              'alertRules?api-version=2022-07-01-preview'
+              'alertRules?api-version=2024-01-01-preview'
 
         headers = {
             'Content-Type': 'application/json',

--- a/dettectinator/plugins/technique_import.py
+++ b/dettectinator/plugins/technique_import.py
@@ -392,7 +392,7 @@ class TechniqueDefenderAlerts(TechniqueAzureAuthBase):
 
         for record in defender_data:
             technique = record['TechniqueId']
-            use_case = record['Title'].strip().replace("'", "")
+            use_case = record['Title'].strip().replace("'", "''").replace("’", "")
             yield technique, use_case, None
 
     @staticmethod

--- a/dettectinator/plugins/technique_import.py
+++ b/dettectinator/plugins/technique_import.py
@@ -392,7 +392,7 @@ class TechniqueDefenderAlerts(TechniqueAzureAuthBase):
 
         for record in defender_data:
             technique = record['TechniqueId']
-            use_case = record['Title'].strip().replace("'", "''")
+            use_case = record['Title'].strip().replace("'", "")
             yield technique, use_case, None
 
     @staticmethod

--- a/dettectinator/plugins/technique_import.py
+++ b/dettectinator/plugins/technique_import.py
@@ -392,7 +392,7 @@ class TechniqueDefenderAlerts(TechniqueAzureAuthBase):
 
         for record in defender_data:
             technique = record['TechniqueId']
-            use_case = record['Title'].strip()
+            use_case = record['Title'].strip().replace("'", "''")
             yield technique, use_case, None
 
     @staticmethod


### PR DESCRIPTION
The current version of the Dettectinator plugin for Sentinel analytics rules (using the Sentinel REST API) only returns technique-level data corresponding to each analytics rule; if a rule is mapped to sub-techniques of a technique in Sentinel Dettectinator will not currently return this information. This request adds code to retrieve sub-techniques alongside techniques, for administration files that can then be used by DeTTECT and so on. The version of the Sentinel API used by the Sentinel plugin has also been updated to the latest version (2024-01-01-preview).

Feedback appreciated.