### PR TITLE
Added Wazuh Technique Import Plugin

### DIFF
--- a/dettectinator/plugins/wazuh_technique_import.py
+++ b/dettectinator/plugins/wazuh_technique_import.py
@@ -1,0 +1,68 @@
+"""
+Dettectinator - The Python library to your DeTT&CT YAML files.
+Wazuh Rules CSV Plugin
+"""
+
+import csv
+from collections.abc import Iterable
+from argparse import ArgumentParser
+import json
+import re
+from anyascii import anyascii
+
+from .technique_import import TechniqueBase
+
+class TechniqueWazuhCsv(TechniqueBase):
+    """
+    Import data from a Wazuh rules CSV file, which contains MITRE ATT&CK techniques in the 'mitre' column
+    """
+
+    def __init__(self, parameters: dict) -> None:
+        super().__init__(parameters)
+        if 'file' not in self._parameters:
+            raise Exception('TechniqueWazuhCsv: "file" parameter is required.')
+
+    @staticmethod
+    def set_plugin_params(parser: ArgumentParser) -> None:
+        """
+        Set command line arguments specific for the plugin
+        :param parser: Argument parser
+        """
+        TechniqueBase.set_plugin_params(parser)
+        parser.add_argument('--file', help='Path of the Wazuh rules csv file to import', required=True)
+
+    def get_data_from_source(self) -> Iterable:
+        """
+        Gets the use-case/technique data from the Wazuh rules CSV source.
+        :return: Iterable, yields technique, detection, applicable_to
+        """
+        file = self._parameters['file']
+        print(f'Reading Wazuh rules from "{file}"')
+
+        with open(file, 'r', encoding='utf-8') as f:
+            reader = csv.DictReader(f)
+            for row in reader:
+                # Skip rows where mitre field is empty or contains only []
+                mitre_field = row.get('mitre', '[]')
+                if not mitre_field or mitre_field == '[]':
+                    continue
+
+                try:
+                    # Parse the mitre field which is stored as a string representation of a list
+                    techniques = json.loads(mitre_field.replace("'", '"'))
+                    
+                    # Get the rule description
+                    description = f"[Rule {row.get('ID', 'Unknown')}] {row.get('Description', '').strip()}"
+                    if not description:
+                        continue
+
+                    # For each technique in the mitre field, yield a separate detection
+                    for technique in techniques:
+                        if technique:  # Skip empty technique IDs
+                            # Take ASCII representation of unicode characters
+                            description = anyascii(description)
+                            yield technique, description, None
+
+                except json.JSONDecodeError:
+                    print(f"Warning: Could not parse MITRE techniques for rule: {row.get('ID', 'Unknown')}")
+                    continue 


### PR DESCRIPTION
# Add Wazuh Rules CSV Plugin for Dettectinator

## Description
This PR adds a new plugin `TechniqueWazuhCsv` to Dettectinator that enables importing Wazuh rules with MITRE ATT&CK technique mappings directly from the Wazuh rules CSV export format.

![image](https://github.com/user-attachments/assets/49f5eb99-6a38-41aa-82bf-d1723bfa3ade)

## Features
- Parses Wazuh rules CSV format with MITRE ATT&CK technique mappings
- Extracts techniques from the 'mitre' column
- Uses rule descriptions from the 'Description' column
- Handles multiple techniques per rule
- Includes rule ID in detection names for traceability
- Supports standard Dettectinator filtering options

## Implementation Details
The plugin extends the `TechniqueBase` class and implements:
- CSV parsing using Python's `csv.DictReader`
- JSON parsing for MITRE technique lists
- Error handling for malformed MITRE technique data
- ASCII conversion for YAML compatibility

## Usage
```bash
python dettectinator.py -p TechniqueWazuhCsv --file wazuh-standard-rules.csv -a "wazuh" -o wazuh-techniques.yaml
```

### Optional Parameters
- `-ri` or `--re_include`: Include rules matching regex pattern
- `-re` or `--re_exclude`: Exclude rules matching regex pattern
- `-l` or `--location_prefix`: Add location prefix to detections
- `-clp` or `--clean_unused_location_prefix`: Clean unused detections

## Testing
- Tested with Wazuh rules CSV export format
- Verified correct parsing of MITRE technique mappings
- Confirmed compatibility with DeTT&CT framework

## Dependencies
- No additional dependencies required
- Uses standard Python libraries (csv, json)
